### PR TITLE
Add sticky headers for employee lists

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,4 +5,7 @@ This project contains a Google Apps Script (`Code.gs`) and an accompanying HTML
 interface (`index.html`) for calculating annual raises for employees across
 multiple departments.
 
+The employee lists now include sticky column headers showing rank, employee
+pay info, pay increase slider, percent increase, and hourly increase.
+
 See `AGENTS.md` for repository contribution guidelines.

--- a/index.html
+++ b/index.html
@@ -142,6 +142,41 @@
     .employee-row.shaded {
       background-color: var(--shade);
     }
+    .employee-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-weight: bold;
+      background-color: var(--dept-bg);
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+    .rank-header {
+      width: 5ch;
+      text-align: right;
+      flex: 0 0 auto;
+      margin-right: 4px;
+    }
+    .info-header {
+      flex: 2 1 0;
+    }
+    .slider-header {
+      flex: 3 2 0;
+      text-align: center;
+    }
+    .percent-header {
+      width: 8ch;
+      text-align: right;
+      flex: 0 0 auto;
+      margin-right: 4px;
+    }
+    .hourly-header {
+      width: 8ch;
+      text-align: right;
+      flex: 0 0 auto;
+      margin-right: 4px;
+    }
     .employee-info {
       display: flex;
       flex-direction: column;
@@ -420,6 +455,17 @@
 
         const listBox = document.createElement('div');
         listBox.className = 'employee-list';
+
+        const headerRow = document.createElement('div');
+        headerRow.className = 'employee-header';
+        headerRow.innerHTML = `
+          <div class="rank-header">Rank</div>
+          <div class="info-header">Employee (Current Pay)</div>
+          <div class="slider-header">Pay Increase</div>
+          <div class="percent-header">% Increase</div>
+          <div class="hourly-header">$/hr Increase</div>
+        `;
+        listBox.appendChild(headerRow);
 
         // Filter employees for this department then sort
         const emps = currentEmps


### PR DESCRIPTION
## Summary
- implement sticky column headers for department employee lists
- document the new header feature

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6847050323b0832298fabd6d610b96e2