### PR TITLE
Add iframe to index page

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -15,3 +15,18 @@ spreadsheet, and the employee rows are reordered so the sort persists
 after refreshing the page.
 
 See `AGENTS.md` for repository contribution guidelines.
+
+To embed the deployed web app in your own `index.html`, ensure `doGet` allows iframe embedding:
+
+```
+function doGet() {
+  return HtmlService.createHtmlOutputFromFile('index')
+    .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+}
+```
+
+Then include the deployed URL inside an iframe in your page:
+
+```
+<iframe src="https://YOUR_WEB_APP_URL"></iframe>
+```

--- a/index.html
+++ b/index.html
@@ -330,6 +330,9 @@
 </head>
 <body>
 
+  <!-- Embedded web app -->
+  <iframe src="https://YOUR_WEB_APP_URL" width="100%" height="600" frameborder="0"></iframe>
+
   <!-- Loading bar (initially hidden) -->
   <div id="loadingContainer">
     <div id="loadingBar"></div>


### PR DESCRIPTION
## Summary
- remove `embed.html`
- embed the web app directly in `index.html`
- clarify embedding instructions in README

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_684708fb8a008322a4113544952d68d5