### PR TITLE
Persist rank sort across reloads

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -260,9 +260,18 @@ function saveEmployeeRanks(rankList) {
     sh.getRange(2,1,sh.getLastRow()-1,sh.getLastColumn())
       .sort([{column:2, ascending:true}, {column:rankIdx+1, ascending:true}]);
   }
+  setRankSort(true);
+}
+
+function setRankSort(flag) {
+  PropertiesService.getScriptProperties().setProperty('rankSort', flag ? 'true' : 'false');
+}
+
+function getRankSort() {
+  return PropertiesService.getScriptProperties().getProperty('rankSort') === 'true';
 }
 
 // Entry point for UI
 function getDashboardData() {
-  return [ getDepartments(), getEmployees() ];
+  return [ getDepartments(), getEmployees(), getRankSort() ];
 }

--- a/README.txt
+++ b/README.txt
@@ -14,6 +14,10 @@ Sorting by rank now updates and saves the sequential ranks back to the
 spreadsheet, and the employee rows are reordered so the sort persists
 after refreshing the page.
 
+The chosen rank sort setting is now saved on the server, so once the list has
+been sorted by rank it will continue to load in that order until "Sort Rank"
+is pressed again.
+
 See `AGENTS.md` for repository contribution guidelines.
 
 To embed the deployed web app in your own `index.html`, ensure `doGet` allows iframe embedding:

--- a/index.html
+++ b/index.html
@@ -426,9 +426,10 @@
     function loadData() {
       startLoadingBar();
       google.script.run
-        .withSuccessHandler(([d, e]) => {
+        .withSuccessHandler(([d, e, rs]) => {
           currentDepts = d;
           currentEmps = e;
+          rankSort = rs;
           renderDepartments();
           finishLoadingBar();
         })
@@ -713,9 +714,10 @@
       // Show loading bar and animate
       startLoadingBar();
       google.script.run
-        .withSuccessHandler(([d,e]) => {
+        .withSuccessHandler(([d,e,rs]) => {
           currentDepts = d;
           currentEmps = e;
+          rankSort = rs;
           populateEditTables();
           finishLoadingBar(() => {
             document.getElementById('editModal').style.display = 'block';


### PR DESCRIPTION
## Summary
- save rank sort state in script properties
- return rank sort value in `getDashboardData`
- set `rankSort` variable on page load and edit modal
- document persistent rank sort feature

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68470b07c5188322849c486b7b3b6e78