### PR TITLE
Implement auto-save on input typing

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -26,6 +26,10 @@ supported, and each change is saved back to the spreadsheet immediately.
 When "Sort Rank" is pressed the screen now fades out and a loading bar
 appears until the sorting and saving completes.
 
+Employee raise amounts entered in the % Up or $/hr Up fields are now
+automatically saved a moment after typing stops so data persists even if the
+page is refreshed.
+
 See `AGENTS.md` for repository contribution guidelines.
 
 To embed the deployed web app in your own `index.html`, ensure `doGet` allows iframe embedding:

--- a/index.html
+++ b/index.html
@@ -437,6 +437,14 @@
     let rankSort = false;
     let loadStartTime = 0;
     let progressIntervalId;
+
+    function debounce(fn, delay) {
+      let id;
+      return (...args) => {
+        clearTimeout(id);
+        id = setTimeout(() => fn(...args), delay);
+      };
+    }
     function showOverlay() {
       document.getElementById('screenOverlay').style.display = 'flex';
     }
@@ -717,8 +725,11 @@
             google.script.run.saveEmployeeAllocation(emp.name, Number(es.value));
           };
 
-          // Percent input onchange: recalc slider, hourlyInput, then update new rate & save
-          percentInput.onchange = () => {
+          const saveAlloc = pct => google.script.run.saveEmployeeAllocation(emp.name, pct);
+          const saveAllocDebounced = debounce(saveAlloc, 600);
+
+          // Percent input oninput: recalc slider, hourlyInput, then update new rate & save
+          percentInput.oninput = () => {
             let pctVal = parseFloat(percentInput.value) || 0;
             if (pctVal < 0) pctVal = 0;
             if (pctVal > 40) pctVal = 40;
@@ -729,12 +740,12 @@
             hourlyInput.value = hrInc.toFixed(2);
 
             updateNewRate();
-            google.script.run.saveEmployeeAllocation(emp.name, pctVal);
             updateRemaining();
+            saveAllocDebounced(pctVal);
           };
 
-          // Hourly input onchange: recalc slider & percentInput, then update new rate & save
-          hourlyInput.onchange = () => {
+          // Hourly input oninput: recalc slider & percentInput, then update new rate & save
+          hourlyInput.oninput = () => {
             let hrVal = parseFloat(hourlyInput.value) || 0;
             if (hrVal < 0) hrVal = 0;
             const pctVal = emp.rate > 0 ? (hrVal / emp.rate) * 100 : 0;
@@ -743,8 +754,8 @@
             percentInput.value = clampedPct.toFixed(2);
 
             updateNewRate();
-            google.script.run.saveEmployeeAllocation(emp.name, clampedPct);
             updateRemaining();
+            saveAllocDebounced(clampedPct);
           };
 
           // Initialize the hourlyInput & newRateDiv on first render


### PR DESCRIPTION
## Summary
- debounce save requests so employee raise inputs auto-save
- document input auto-saving behavior

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6847147f4a408322aefb3e7b207f5afa