### PR TITLE
Fix allocation persistence when ranking

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -43,3 +43,4 @@ Then include the deployed URL inside an iframe in your page:
 Bug Fixes
 ---------
 - Fixed server functions to handle empty sheets without errors.
+- Fixed rank change resetting raise inputs by keeping allocations in memory.

--- a/index.html
+++ b/index.html
@@ -639,12 +639,14 @@
             const hrInc = emp.rate * (pctEmp / 100);
             hourlyInput.value = hrInc.toFixed(2);
 
+            emp.allocation = pctEmp;
             updateNewRate();
             updateRemaining();
           };
 
           // Slider onchange: persist allocation
           es.onchange = () => {
+            emp.allocation = Number(es.value);
             google.script.run.saveEmployeeAllocation(emp.name, Number(es.value));
           };
 
@@ -662,6 +664,7 @@
             const hrInc = emp.rate * (pctVal / 100);
             hourlyInput.value = hrInc.toFixed(2);
 
+            emp.allocation = pctVal;
             updateNewRate();
             updateRemaining();
             saveAllocDebounced(pctVal);
@@ -676,6 +679,7 @@
             es.value = clampedPct;
             percentInput.value = clampedPct.toFixed(2);
 
+            emp.allocation = clampedPct;
             updateNewRate();
             updateRemaining();
             saveAllocDebounced(clampedPct);


### PR DESCRIPTION
## Summary
- keep employee allocation in memory during slider/percent/hourly edits
- document fix in README

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685d66590f4c83229598ed21f2ea6560