### PR TITLE
Add manual save button to header

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -23,6 +23,10 @@ The "Reset Allocations" button now clears all saved allocation percentages on
 the server so slider values no longer revert when ranks are adjusted or panels
 are re-rendered.
 
+A "Save" button is available in the page header. Clicking it manually persists
+all current department and employee allocations, hourly increases, and ranks to
+the spreadsheet as a fallback to the automatic saves.
+
 See `AGENTS.md` for repository contribution guidelines.
 
 To embed the deployed web app in your own `index.html`, ensure `doGet` allows iframe embedding:

--- a/index.html
+++ b/index.html
@@ -38,6 +38,19 @@
       font-weight: bold;
       color: var(--accent);
     }
+    #header #saveBtn {
+      position: absolute;
+      left: 20px;
+      top: 50%;
+      transform: translateY(-50%);
+      font-size: 1.2em;
+      padding: 8px 20px;
+      border: none;
+      border-radius: 6px;
+      background: var(--accent);
+      color: #fff;
+      cursor: pointer;
+    }
     #header #logo {
       position: absolute;
       right: 20px;
@@ -351,6 +364,7 @@
 
   <!-- HEADER: title centered + logo on right (with breathing room) -->
   <div id="header">
+    <button id="saveBtn" onclick="manualSave()">💾 Save</button>
     <h1 class="title">Dublin Cleaner’s Raise Allocation</h1>
     <img id="logo" src="https://www.dublincleaners.com/wp-content/uploads/2024/12/Dublin-Logos-stacked.png" alt="Dublin Cleaners Logo">
   </div>
@@ -762,6 +776,18 @@
         sl.value = 0;
         sl.dispatchEvent(new Event('input'));
       });
+    }
+
+    function manualSave() {
+      currentDepts.forEach(d => {
+        google.script.run.saveDepartmentAllocation(d.name, Number(d.pct));
+      });
+      currentEmps.forEach(e => {
+        google.script.run.saveEmployeeAllocation(e.name, Number(e.allocation));
+        google.script.run.saveEmployeeHourlyIncrease(e.name, Number(e.hourlyIncrease));
+        google.script.run.saveEmployeeRank(e.name, e.rank);
+      });
+      alert('All data saved');
     }
 
     function editData() {


### PR DESCRIPTION
## Summary
- add save button CSS and HTML in header
- implement `manualSave` function to persist allocations
- document manual save button in README

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_688b5c8fdff8832296660adc4826ecf4