### PR TITLE
Fix desktop employee grid spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -569,23 +569,37 @@
       #departments {
         grid-template-columns: repeat(3, minmax(0, 1fr));
       }
-      .employee-row {
-        grid-template-columns: 80px 1.5fr 1fr 1fr 1fr;
-        grid-template-areas:
-          'rank info slider percent-label hourly-label'
-          'rank info slider percent-input hourly-input'
-          'rank info slider percent-input hourly-input';
-        align-items: center;
-      }
-      .employee-header {
-        display: grid;
-        grid-template-columns: 80px 1.5fr 1fr 1fr 1fr;
-        align-items: center;
-        gap: 8px;
-      }
-      .employee-row .rank-cell {
-        align-self: stretch;
-      }
+    .employee-row {
+      grid-template-columns:
+        72px
+        minmax(96px, 1.45fr)
+        minmax(90px, 1.1fr)
+        minmax(52px, 0.9fr)
+        minmax(52px, 0.9fr);
+      grid-template-areas:
+        'rank info slider percent-label hourly-label'
+        'rank info slider percent-input hourly-input'
+        'rank info rate percent-input hourly-input';
+      align-items: center;
+      column-gap: 8px;
+    }
+    .employee-header {
+      display: grid;
+      grid-template-columns:
+        72px
+        minmax(96px, 1.45fr)
+        minmax(90px, 1.1fr)
+        minmax(52px, 0.9fr)
+        minmax(52px, 0.9fr);
+      align-items: center;
+      column-gap: 8px;
+    }
+    .rank-controls {
+      grid-area: rank;
+    }
+    .employee-row .rank-cell {
+      align-self: stretch;
+    }
       .rank-controls {
         flex-direction: column;
         align-items: center;
@@ -595,13 +609,10 @@
         width: 36px;
         height: 36px;
       }
-      .label-text {
-        margin-left: 4px;
-        margin-right: 2px;
-      }
-      .rank-controls {
-        margin-right: 4px;
-      }
+    .label-text {
+      margin-left: 4px;
+      margin-right: 2px;
+    }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- prevent employee information from collapsing in the desktop three-column view by giving grid tracks minimum widths
- ensure the raise summary row has a defined grid area and consistent spacing on large screens

## Testing
- node --version

------
https://chatgpt.com/codex/tasks/task_b_68e03773a970832eb964c9ba4444f0f4