### PR TITLE
Ensure consistent department card widths across breakpoints

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,8 @@
       gap: 16px;
       width: min(100%, var(--max-width));
       margin: 0 auto 130px auto;
-      grid-template-columns: 1fr;
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+      justify-content: center;
     }
     .department {
       background: var(--panel-bg);
@@ -507,7 +508,7 @@
       }
       #departments {
         gap: 20px;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
       }
       .employee-row {
         padding: 14px 16px;
@@ -567,7 +568,7 @@
         grid-column: 1 / -1;
       }
       #departments {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
       }
     .employee-row {
       grid-template-columns:


### PR DESCRIPTION
## Summary
- update the department grid to use responsive minmax columns so cards stay a consistent width across viewports
- center the grid layout to keep card spacing tidy on wide screens

## Testing
- node --version

------
https://chatgpt.com/codex/tasks/task_b_68e039e84f18832ea7ed56b4ad0bdbb0