### PR TITLE
Broaden department cards for three-column layout

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -53,6 +53,8 @@ Responsive Design Refresh
   and touch-friendly buttons that adapt to available width.
 - Restyled employee rows to reflow into stacked sections on narrow screens
   while preserving the original horizontal layout on large displays.
+- Expanded large-screen department columns so three-card layouts have generous
+  width for the rank, slider, and pay data without horizontal scrolling.
 
 See `AGENTS.md` for repository contribution guidelines.
 

--- a/index.html
+++ b/index.html
@@ -198,7 +198,8 @@
       gap: 16px;
       width: min(100%, var(--max-width));
       margin: 0 auto 130px auto;
-      grid-template-columns: 1fr;
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+      justify-content: center;
     }
     .department {
       background: var(--panel-bg);
@@ -507,7 +508,7 @@
       }
       #departments {
         gap: 20px;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
       }
       .employee-row {
         padding: 14px 16px;
@@ -546,7 +547,10 @@
     }
 
 
-@media (min-width: 1024px) {
+    @media (min-width: 1024px) {
+      :root {
+        --max-width: 1240px;
+      }
       #header {
         grid-template-columns: 1.2fr 1.2fr 1fr;
         grid-template-areas:
@@ -567,52 +571,59 @@
         grid-column: 1 / -1;
       }
       #departments {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(370px, 1fr));
       }
-    .employee-row {
-      grid-template-columns:
-        72px
-        minmax(96px, 1.45fr)
-        minmax(90px, 1.1fr)
-        minmax(52px, 0.9fr)
-        minmax(52px, 0.9fr);
-      grid-template-areas:
-        'rank info slider percent-label hourly-label'
-        'rank info slider percent-input hourly-input'
-        'rank info rate percent-input hourly-input';
-      align-items: center;
-      column-gap: 8px;
-    }
-    .employee-header {
-      display: grid;
-      grid-template-columns:
-        72px
-        minmax(96px, 1.45fr)
-        minmax(90px, 1.1fr)
-        minmax(52px, 0.9fr)
-        minmax(52px, 0.9fr);
-      align-items: center;
-      column-gap: 8px;
-    }
-    .rank-controls {
-      grid-area: rank;
-    }
-    .employee-row .rank-cell {
-      align-self: stretch;
-    }
+      .employee-row {
+        grid-template-columns:
+          72px
+          minmax(96px, 1.45fr)
+          minmax(90px, 1.1fr)
+          minmax(52px, 0.9fr)
+          minmax(52px, 0.9fr);
+        grid-template-areas:
+          'rank info slider percent-label hourly-label'
+          'rank info slider percent-input hourly-input'
+          'rank info rate percent-input hourly-input';
+        align-items: center;
+        column-gap: 8px;
+      }
+      .employee-header {
+        display: grid;
+        grid-template-columns:
+          72px
+          minmax(96px, 1.45fr)
+          minmax(90px, 1.1fr)
+          minmax(52px, 0.9fr)
+          minmax(52px, 0.9fr);
+        align-items: center;
+        column-gap: 8px;
+      }
       .rank-controls {
+        grid-area: rank;
         flex-direction: column;
         align-items: center;
         gap: 4px;
+      }
+      .employee-row .rank-cell {
+        align-self: stretch;
       }
       .rank-controls button {
         width: 36px;
         height: 36px;
       }
-    .label-text {
-      margin-left: 4px;
-      margin-right: 2px;
+      .label-text {
+        margin-left: 4px;
+        margin-right: 2px;
+      }
     }
+
+    @media (min-width: 1280px) {
+      :root {
+        --max-width: 1340px;
+      }
+      #departments {
+        grid-template-columns: repeat(auto-fit, minmax(390px, 1fr));
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- update the department grid to use responsive minmax columns so cards stay a consistent width across viewports
- center the grid layout to keep card spacing tidy on wide screens
- expand large-screen breakpoints so three-column layouts show full card content without horizontal scrolling

## Testing
- node --version

------
https://chatgpt.com/codex/tasks/task_b_68e039e84f18832ea7ed56b4ad0bdbb0