### PR TITLE
Remove raise column headers from department cards

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -55,6 +55,8 @@ Responsive Design Refresh
   while preserving the original horizontal layout on large displays.
 - Expanded large-screen department columns so three-card layouts have generous
   width for the rank, slider, and pay data without horizontal scrolling.
+- Removed the raise/percent/hourly column headers and tightened the minimum
+  department card width for a more compact grid on all breakpoints.
 
 See `AGENTS.md` for repository contribution guidelines.
 

--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
       gap: 16px;
       width: min(100%, var(--max-width));
       margin: 0 auto 130px auto;
-      grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
       justify-content: center;
     }
     .department {
@@ -508,7 +508,7 @@
       }
       #departments {
         gap: 20px;
-        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
       }
       .employee-row {
         padding: 14px 16px;
@@ -881,9 +881,6 @@
         headerRow.innerHTML = `
           <div class="rank-header">Rank</div>
           <div class="info-header">Emp &amp; Pay</div>
-          <div class="slider-header">Raise</div>
-          <div class="percent-header">% Up</div>
-          <div class="hourly-header">$/hr Up</div>
         `;
         listBox.appendChild(headerRow);
 


### PR DESCRIPTION
## Summary
- hide the raise, percent, and hourly column headers in each department panel
- shrink the minimum card width so more departments fit on screen at once
- note the updated card sizing in the responsive design documentation

## Testing
- node --version

------
https://chatgpt.com/codex/tasks/task_b_68e03ea975dc832eb94ec4218789abdf