### PR TITLE
Reduce employee card vertical spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,11 +243,11 @@
 
     /* ------------ EMPLOYEE LIST WITH FLEX ITEMS ------------ */
     .employee-list {
-      padding: 16px;
+      padding: 14px;
       flex: 1 1 auto;
       display: flex;
       flex-direction: column;
-      gap: 10px;
+      gap: 8px;
       overflow-y: auto;
     }
     .employee-row {
@@ -257,8 +257,8 @@
         "rank info adjustments"
         "rate rate rate"
         "slider slider slider";
-      gap: 10px;
-      padding: 12px;
+      gap: 8px;
+      padding: 9px 10px;
       border-radius: var(--radius-sm);
       min-height: var(--input-height);
       background: rgba(0, 0, 0, 0.02);
@@ -303,7 +303,7 @@
     .employee-info {
       display: flex;
       flex-direction: column;
-      gap: 4px;
+      gap: 3px;
       min-width: 0;
       overflow: hidden;
       grid-area: info;
@@ -332,7 +332,7 @@
       display: flex;
       flex-direction: column;
       align-items: flex-end;
-      gap: 6px;
+      gap: 5px;
     }
     .adjustment-field {
       display: flex;
@@ -499,12 +499,12 @@
         grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
       }
       .employee-row {
-        padding: 14px 16px;
+        padding: 10px 12px;
       }
       .employee-adjustments {
         flex-direction: row;
         align-items: center;
-        gap: 12px;
+        gap: 9px;
       }
     }
 


### PR DESCRIPTION
## Summary
- tighten spacing within employee cards by reducing padding and internal gaps
- adjust layout spacing on larger viewports to maintain consistent 25% compaction

## Testing
- node --version

------
https://chatgpt.com/codex/tasks/task_b_68e0482adb78832eac0a8b7e132ff48e