### PR TITLE
Allow dragging from the full employee card

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -15,11 +15,11 @@ arrows moves the selected employee higher or lower in the list one spot at a
 time until the top or bottom is reached. Manual number entry is still
 supported, and each change is saved back to the spreadsheet immediately.
 
-Employee cards can also be reordered directly with drag and drop. Grab the
-handle above the rank arrows to move an employee to a new position. As you
-drop, the list re-numbers automatically, alternating row shading updates to
-match, and new ranks are saved instantly. Dragging is available whenever the
-active planning year is in edit mode.
+Employee cards can also be reordered directly with drag and drop. You can grab
+anywhere on the card (outside of editable fields) to move an employee to a new
+position. As you drop, the list re-numbers automatically, alternating row
+shading updates to match, and new ranks are saved instantly. Dragging is
+available whenever the active planning year is in edit mode.
 
 Employee raise amounts entered in the % Up or $/hr Up fields are now
 automatically saved a moment after typing stops so data persists even if the
@@ -98,3 +98,5 @@ Bug Fixes
 - Adjusted position of the "Saved!" message so it no longer overlaps the Save button.
 - Smoothed typing in the % and $/hr inputs so values are only formatted after entry is complete.
 - Cleared the % and $/hr inputs by default so new rows start blank instead of showing 0.00.
+- Fixed drag and drop so the entire employee card is draggable and focusable,
+  eliminating cases where dragging silently failed on some browsers.

--- a/index.html
+++ b/index.html
@@ -264,6 +264,7 @@
       min-height: var(--input-height);
       background: rgba(0, 0, 0, 0.02);
       align-items: center;
+      cursor: grab;
     }
     .employee-row.shaded {
       background-color: rgba(0, 115, 230, 0.08);
@@ -427,6 +428,12 @@
     }
     .employee-row.is-dragging {
       opacity: 0.65;
+      cursor: grabbing;
+    }
+    .employee-row.is-focused,
+    .employee-row:focus-visible {
+      outline: 2px solid rgba(0, 115, 230, 0.35);
+      outline-offset: 2px;
     }
     .employee-list.is-dragging-over {
       outline: 2px dashed var(--accent);
@@ -718,6 +725,17 @@
       deptName: ''
     };
 
+    function isDragBlockedElement(element) {
+      if (!element) {
+        return false;
+      }
+      if (element.closest('.drag-handle')) {
+        return false;
+      }
+      const blockedSelectors = ['input', 'textarea', 'select', 'button', '[contenteditable="true"]'];
+      return blockedSelectors.some(selector => element.closest(selector));
+    }
+
     function getDragAfterElement(container, y) {
       const rows = [...container.querySelectorAll('.employee-row:not(.is-dragging)')];
       return rows.reduce((closest, child) => {
@@ -756,6 +774,8 @@
       });
       if (dragState.row) {
         dragState.row.classList.remove('is-dragging');
+        dragState.row.classList.remove('is-focused');
+        dragState.row.setAttribute('aria-grabbed', 'false');
       }
       dragState.row = null;
       dragState.deptName = '';
@@ -1064,14 +1084,31 @@
           row.dataset.empName = emp.name;
           if (editingEnabled) {
             row.draggable = true;
+            row.tabIndex = 0;
+            row.setAttribute('role', 'option');
+            row.setAttribute('aria-grabbed', 'false');
+            row.addEventListener('focusin', () => {
+              row.classList.add('is-focused');
+            });
+            row.addEventListener('focusout', event => {
+              if (!row.contains(event.relatedTarget)) {
+                row.classList.remove('is-focused');
+              }
+            });
+            row.addEventListener('mousedown', event => {
+              if (!isDragBlockedElement(event.target)) {
+                row.focus();
+              }
+            });
             row.addEventListener('dragstart', event => {
-              if (!event.target.closest('.drag-handle')) {
+              if (isDragBlockedElement(event.target)) {
                 event.preventDefault();
                 return;
               }
               dragState.row = row;
               dragState.deptName = dept.name;
               row.classList.add('is-dragging');
+              row.setAttribute('aria-grabbed', 'true');
               if (event.dataTransfer) {
                 event.dataTransfer.effectAllowed = 'move';
                 event.dataTransfer.setData('text/plain', emp.name);
@@ -1083,6 +1120,8 @@
                 dragState.deptName = '';
               }
               row.classList.remove('is-dragging');
+              row.classList.remove('is-focused');
+              row.setAttribute('aria-grabbed', 'false');
               listBox.classList.remove('is-dragging-over');
             });
           }


### PR DESCRIPTION
## Summary
- allow employee cards to start drag-and-drop reordering from any non-editable surface
- add cursor, focus, and aria updates so draggable cards communicate their state while moving
- document the broader drag target change in the README

## Testing
- node --version

------
https://chatgpt.com/codex/tasks/task_b_68e04c5314fc832e922c3ea929b9f3a5