### PR TITLE
Reduce header logo width to 60px

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -66,6 +66,8 @@ Responsive Design Refresh
   width for the rank, slider, and pay data without horizontal scrolling.
 - Removed the raise/percent/hourly column headers and tightened the minimum
   department card width for a more compact grid on all breakpoints.
+- Reduced the header logo and title scale to keep the hero area compact on
+  smaller displays, with the logo capped at 60px wide.
 
 Edit Data Workspace
 -------------------

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
     }
     #header .title {
       margin: 0;
-      font-size: clamp(1.6rem, 1.25rem + 1.2vw, 2.4rem);
+      font-size: clamp(0.8rem, 0.625rem + 0.6vw, 1.2rem);
       font-weight: 700;
       color: var(--accent);
       text-align: left;
@@ -82,7 +82,7 @@
       display: none;
     }
     #header #logo {
-      max-width: 180px;
+      max-width: 60px;
       height: auto;
       justify-self: flex-start;
     }


### PR DESCRIPTION
## Summary
- cap the header logo at 60px wide so it takes up less space in the hero area
- update the responsive design notes to mention the tighter logo cap

## Testing
- node --version

------
https://chatgpt.com/codex/tasks/task_b_68e053cf6c60832ea7c11b657a08f9f8